### PR TITLE
t.rast.sample: Support installation on systems that implemented PEP 668

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ PGM = t.rast.sample
 include $(MODULE_TOPDIR)/include/Make/Script.make
 
 python-requirements:
-	pip install -r requirements.txt
+	pip install --break-system-packages -r requirements.txt
 
 default: python-requirements script $(TEST_DST)


### PR DESCRIPTION
During compilation, installation of requirements fails with Python 3.12 on Ubuntu.
It will likely fail on all systems that implemented PEP668: https://peps.python.org/pep-0668/

This PR updates `pip install` for PEP668-compliant systems / distros.